### PR TITLE
Only run spec files for files that show a git diff change

### DIFF
--- a/e2e/map2test.js
+++ b/e2e/map2test.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const path = require('path');
+const spawnSync = require('child_process').spawnSync;
+const glob = require('glob');
+/**
+ * Runs the command "git diff --name-only ..master" to find the differences between this branch
+ * and the master branch.
+ * @returns string[] of the file paths
+ */
+let gitdiff = () => {
+  const task = 'git';
+  const args = ["diff", "--name-only", "..master"]
+  let diffs = spawnSync(task, args).output[1].toString();
+  return diffs.split('\n');
+}
+
+/**
+ * Reads the map2test json file.
+ * @returns object directly mapping to the map2test json file
+ */
+let readMap2Test = () => {
+  const map2testPath = path.resolve('e2e', 'map2test.json');
+  return JSON.parse(fs.readFileSync(map2testPath));
+}
+
+/**
+ * Matches the diff paths and returns a list of the test suites
+ * @param map2Test object of the map2test json file
+ * @param diffs string[] a list of file diffs
+ * @returns string[] a list of test suites
+ */
+let diffPath2suite = (map2Test, diffs) => {
+  let suites = [];
+  // for each diff'd file
+  for (let diff of diffs) {
+    let diffFile = path.resolve(diff);
+    // cycle through each mapping object
+    for (let mapFiles of map2Test.mapping) {
+      // check if the mapFiles path matches the diff'd file
+      for (let mapFilePath of mapFiles.paths) {
+        // use globbing because Protractor required globbing. 
+        let files = glob.sync(mapFilePath);
+        for (let file of files) {
+          // if the diffFile matches any part of the file, we have a match
+          if (diffFile.indexOf(file) !== -1) {
+            // add the suites as long as the file does not exist
+            for (let suite of mapFiles.suites) {
+              if (!suites.includes(suite)) {
+                suites.push(suite);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return suites;
+}
+
+/**
+ * Gets the specs from the Protractor test
+ * @param map2Test object of the map2test json file
+ */
+let getSpecs = (map2Test, suites) => {
+  let specs = [];
+  for (let suite of suites) {
+    for (let spec of map2Test.suites[suite]) {
+      if (!specs.includes(spec)) {
+        specs.push(spec);
+      }
+    }
+  }
+  return specs;
+}
+
+// read file to get a list of specs
+let map2Test = readMap2Test()
+let suites = diffPath2suite(map2Test, gitdiff());
+let specs = getSpecs(map2Test, suites);
+
+
+// import protractor.conf.js and add spec on
+let protractorConf = require('../protractor.conf').config;
+protractorConf.specs = specs;
+console.log('specs override');
+console.log(specs.toString());
+console.log('==============');
+
+console.log('protractor config:');
+console.log(protractorConf);
+console.log('==============');
+exports.config = protractorConf;

--- a/e2e/map2test.json
+++ b/e2e/map2test.json
@@ -1,0 +1,40 @@
+{
+  "mapping": [ {
+      "paths": [ "src/app/contacts/contact-detail/" ],
+      "suites": [ "routing", "viewContact" ]
+    }, {
+      "paths": [ "src/app/contacts/contact-list/" ],
+      "suites": [ "routing", "contactList" ]
+    }, {
+      "paths": [ "src/app/contacts/new-contact/"],
+      "suites": [ "routing", "addContact" ]
+    }, {
+      "paths": [ "src/app/shared/" ],
+      "suites": [ "routing", "viewContact", "contactList", "addContact" ]
+    }, {
+      "paths": [
+        "app/app-routing.module.ts",
+        "app/app.component.ts",
+        "app/app.material.module.ts",
+        "app/app.module.ts"
+       ],
+      "suites": [ "routing" ]
+    }
+  ],
+  "suites":  {
+    "viewContact": [
+      "view-contact.e2e-spec.ts"
+    ],
+    "contactList": [
+      "contact-list.e2e-spec.ts"
+    ],
+    "addContact": [
+      "add-contact.e2e-spec.ts",
+      "add-second-contact.e2e-spec.ts",
+      "invalid-contact.e2e-spec.ts"
+    ],
+    "routing": [
+      "routing.e2e-spec.ts"
+    ]
+  }
+}

--- a/e2e/routing.e2e-spec.ts
+++ b/e2e/routing.e2e-spec.ts
@@ -1,0 +1,25 @@
+import {
+  AddContactPageObject,
+  ContactListPageObject,
+  ViewContactPageObject
+} from './po';
+
+describe('routing', () => {
+  it('should load the contact list page', () => {
+    let contactList = new ContactListPageObject();
+    contactList.navigateTo();
+    contactList.verifyUrl();
+  });
+
+  it('should load the add contact page', () => {
+    let addContact = new AddContactPageObject();
+    addContact.navigateTo();
+    addContact.verifyUrl();
+  });
+
+  it('should load a contact detail page', () => {
+    let viewContact = new ViewContactPageObject();
+    viewContact.navigateTo(1);
+    viewContact.verifyUrl(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "protractor"
+    "e2e": "protractor",
+    "e2e-smoke": "protractor e2e/map2test.js"
   },
   "private": true,
   "dependencies": {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -15,6 +15,8 @@ exports.config = {
     }
   },
   directConnect: !process.env.IS_JENKINS,
+
+  // export URL=https://contacts-app-starter.firebaseapp.com
   baseUrl: process.env.URL || 'http://localhost:4200/',
 
   // Jasmine


### PR DESCRIPTION
### Background

To decrease the run times of e2e tests by only running tests that make
sense to the git diffs from master. See [stackoverflow issue about log running tests](https://stackoverflow.com/questions/45371903/protractor-tests-stop-after-2-hours-30-minutes-with-error-e-launcher-process-e#comment77728719_45371903)

### Assumptions

Some of the assumptions made:
- Changes are being made off of a non-master branch
- All changes are staged in a commit
- Mapping of components to e2e tests makes sense and maintained

### Example

Let's say we change the contacts-detail page html template. We probably
do not need to run every e2e test, instead we should only run the router
and contact-detail suites. Luckily for us, those map directly to
`e2e/routing.e2e-spec.ts` and `e2e/view-contact.e2e-spec.ts`. This means we
will run only 19 out of the 30 specs.